### PR TITLE
Deserialise CHS Insolvency Delta

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,8 +41,6 @@
 			${project.basedir}/target/site/jacoco-it/jacoco.xml
 		</sonar.coverage.jacoco.xmlReportPaths>
 		<sonar.jacoco.reports>${project.basedir}/target/site</sonar.jacoco.reports>
-		<maven.compiler.source>11</maven.compiler.source>
-		<maven.compiler.target>11</maven.compiler.target>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 		<ch-kafka.version>1.4.2</ch-kafka.version>
 		<structured-logging.version>1.9.12</structured-logging.version>
 		<kafka-models.version>1.0.25</kafka-models.version>
-		<private-api-sdk-java.version>2.0.65</private-api-sdk-java.version>
+		<private-api-sdk-java.version>2.0.105</private-api-sdk-java.version>
 		<api-sdk-manager-java-library.version>1.0.4</api-sdk-manager-java-library.version>
 		<jib-maven-plugin.version>3.1.1</jib-maven-plugin.version>
 		<skip.integration.tests>false</skip.integration.tests>
@@ -38,8 +38,11 @@
 
 		<!--sonar configuration-->
 		<sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/target/site/jacoco/jacoco.xml,
-			${project.basedir}/target/site/jacoco-it/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+			${project.basedir}/target/site/jacoco-it/jacoco.xml
+		</sonar.coverage.jacoco.xmlReportPaths>
 		<sonar.jacoco.reports>${project.basedir}/target/site</sonar.jacoco.reports>
+		<maven.compiler.source>11</maven.compiler.source>
+		<maven.compiler.target>11</maven.compiler.target>
 	</properties>
 
 	<dependencies>

--- a/src/main/java/uk/gov/companieshouse/insolvency/delta/processor/InsolvencyDeltaProcessor.java
+++ b/src/main/java/uk/gov/companieshouse/insolvency/delta/processor/InsolvencyDeltaProcessor.java
@@ -1,7 +1,6 @@
 package uk.gov.companieshouse.insolvency.delta.processor;
 
-import java.util.Objects;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,9 +8,12 @@ import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.api.delta.InsolvencyDelta;
 import uk.gov.companieshouse.delta.ChsDelta;
 import uk.gov.companieshouse.insolvency.delta.exception.RetryableErrorException;
 import uk.gov.companieshouse.insolvency.delta.producer.InsolvencyDeltaProducer;
+
+import java.util.Objects;
 
 
 @Component
@@ -34,6 +36,10 @@ public class InsolvencyDeltaProcessor {
             final String receivedTopic =
                     Objects.requireNonNull(headers.get(KafkaHeaders.RECEIVED_TOPIC)).toString();
             final ChsDelta payload = chsDelta.getPayload();
+
+            // convert ChsDelta to InsolvencyDelta
+            ObjectMapper mapper = new ObjectMapper();
+            InsolvencyDelta insolvencyDelta = mapper.readValue(payload.getData(), InsolvencyDelta.class);
 
         } catch (RetryableErrorException ex) {
             retryDeltaMessage(chsDelta);

--- a/src/main/java/uk/gov/companieshouse/insolvency/delta/serialization/ChsDeltaDeserializer.java
+++ b/src/main/java/uk/gov/companieshouse/insolvency/delta/serialization/ChsDeltaDeserializer.java
@@ -17,7 +17,6 @@ public class ChsDeltaDeserializer implements Deserializer<ChsDelta> {
     @Override
     public ChsDelta deserialize(String topic, byte[] data) {
         try {
-            // TODO: Zahid: Use AvroDeserializer after adding util method in ch-kafka
             Decoder decoder = DecoderFactory.get().binaryDecoder(data, null);
             DatumReader<ChsDelta> reader = new ReflectDatumReader<>(ChsDelta.class);
             return reader.read(null, decoder);

--- a/src/main/java/uk/gov/companieshouse/insolvency/delta/transformer/InsolvencyApiTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/insolvency/delta/transformer/InsolvencyApiTransformer.java
@@ -1,4 +1,4 @@
-package uk.gov.companieshouse.insolvency.delta.tranformer;
+package uk.gov.companieshouse.insolvency.delta.transformer;
 
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/uk/gov/companieshouse/insolvency/delta/transformer/InsolvencyApiTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/insolvency/delta/transformer/InsolvencyApiTransformer.java
@@ -1,12 +1,13 @@
 package uk.gov.companieshouse.insolvency.delta.transformer;
 
 import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.api.delta.InsolvencyDelta;
 
 @Component
 public class InsolvencyApiTransformer {
 
-    public String transform(String input) {
+    public String transform(InsolvencyDelta insolvencyDelta) {
         // TODO: Use mapStruct to transform json object to Open API generated object
-        return input;
+        return insolvencyDelta.toString();
     }
 }

--- a/src/test/java/uk/gov/companieshouse/insolvency/delta/processor/InsolvencyDeltaProcessorTest.java
+++ b/src/test/java/uk/gov/companieshouse/insolvency/delta/processor/InsolvencyDeltaProcessorTest.java
@@ -1,0 +1,34 @@
+package uk.gov.companieshouse.insolvency.delta.processor;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+import uk.gov.companieshouse.delta.ChsDelta;
+import uk.gov.companieshouse.insolvency.delta.producer.InsolvencyDeltaProducer;
+
+@ExtendWith(MockitoExtension.class)
+public class InsolvencyDeltaProcessorTest {
+
+    private InsolvencyDeltaProcessor deltaProcessor;
+
+    @Mock
+    private InsolvencyDeltaProducer insolvencyDeltaProducer;
+
+    @BeforeEach
+    void setUp() {
+        deltaProcessor = new InsolvencyDeltaProcessor(insolvencyDeltaProducer);
+    }
+
+    @Test
+    void processDeltaSuccessful() throws JsonProcessingException {
+        ChsDelta mockChsDelta = ChsDelta.newBuilder().setData("test").setContextId("context_id").setAttempt(1).build();
+        Message<ChsDelta> chsDelta = MessageBuilder.withPayload(mockChsDelta).setHeader("foo", "bar").build();
+
+        deltaProcessor.processDelta(chsDelta);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/insolvency/delta/processor/InsolvencyDeltaProcessorTest.java
+++ b/src/test/java/uk/gov/companieshouse/insolvency/delta/processor/InsolvencyDeltaProcessorTest.java
@@ -1,15 +1,25 @@
 package uk.gov.companieshouse.insolvency.delta.processor;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.util.FileCopyUtils;
+import uk.gov.companieshouse.api.delta.*;
 import uk.gov.companieshouse.delta.ChsDelta;
 import uk.gov.companieshouse.insolvency.delta.producer.InsolvencyDeltaProducer;
+import uk.gov.companieshouse.insolvency.delta.transformer.InsolvencyApiTransformer;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class InsolvencyDeltaProcessorTest {
@@ -19,16 +29,72 @@ public class InsolvencyDeltaProcessorTest {
     @Mock
     private InsolvencyDeltaProducer insolvencyDeltaProducer;
 
+    @Mock
+    private InsolvencyApiTransformer transformer;
+
     @BeforeEach
     void setUp() {
-        deltaProcessor = new InsolvencyDeltaProcessor(insolvencyDeltaProducer);
+        deltaProcessor = new InsolvencyDeltaProcessor(insolvencyDeltaProducer, transformer);
     }
 
     @Test
-    void processDeltaSuccessful() throws JsonProcessingException {
-        ChsDelta mockChsDelta = ChsDelta.newBuilder().setData("test").setContextId("context_id").setAttempt(1).build();
-        Message<ChsDelta> chsDelta = MessageBuilder.withPayload(mockChsDelta).setHeader("foo", "bar").build();
+    @DisplayName("Transforms a kafka message containing a ChsDelta payload into an InsolvencyDelta")
+    void When_ValidChsDeltaMessage_Expect_ValidInsolvencyDeltaMapping() throws IOException {
+        Message<ChsDelta> mockChsDeltaMessage = createChsDeltaMessage();
+        InsolvencyDelta expectedInsolvencyDelta = createInsolvencyDelta();
+        when(transformer.transform(expectedInsolvencyDelta)).thenCallRealMethod();
 
-        deltaProcessor.processDelta(chsDelta);
+        deltaProcessor.processDelta(mockChsDeltaMessage);
+
+        verify(transformer).transform(expectedInsolvencyDelta);
+    }
+
+    private Message<ChsDelta> createChsDeltaMessage() throws IOException {
+        InputStreamReader exampleInsolvencyJsonPayload = new InputStreamReader(
+                ClassLoader.getSystemClassLoader().getResourceAsStream("insolvency-delta-example.json"));
+        String insolvencyData = FileCopyUtils.copyToString(exampleInsolvencyJsonPayload);
+
+        ChsDelta mockChsDelta = ChsDelta.newBuilder()
+                .setData(insolvencyData)
+                .setContextId("context_id")
+                .setAttempt(1)
+                .build();
+
+        return MessageBuilder
+                .withPayload(mockChsDelta)
+                .setHeader(KafkaHeaders.RECEIVED_TOPIC, "test")
+                .setHeader("INSOLVENCY_DELTA_RETRY_COUNT", 1)
+                .build();
+    }
+
+    private InsolvencyDelta createInsolvencyDelta() {
+        PractitionerAddress address = new PractitionerAddress();
+        address.setAddressLine1("Yerrill Murphy Edelman House");
+        address.setAddressLine2("1238 High Road");
+        address.setLocality("Whetstone");
+        address.setRegion("London");
+        address.setPostalCode("N20 0LH");
+
+        Appointment appointment = new Appointment();
+        appointment.setForename("Bernard");
+        appointment.setSurname("Hoffman");
+        appointment.setApptType(Appointment.ApptTypeEnum.NUMBER_1);
+        appointment.setApptDate("20200506");
+        appointment.setPractitionerAddress(address);
+
+        CaseNumber caseNumber = new CaseNumber();
+        caseNumber.setCaseNumber(1);
+        caseNumber.setCaseType(CaseNumber.CaseTypeEnum.MEMBERS_VOLUNTARY_LIQUIDATION);
+        caseNumber.setCaseTypeId(CaseNumber.CaseTypeIdEnum.NUMBER_1);
+        caseNumber.setSwornDate("20200429");
+        caseNumber.windUpDate("20200506");
+        caseNumber.addAppointmentsItem(appointment);
+
+        Insolvency insolvency = new Insolvency();
+        insolvency.setDeltaAt("20211008152823383176");
+        insolvency.setCompanyNumber("02588581");
+        insolvency.addCaseNumbersItem(caseNumber);
+
+        return new InsolvencyDelta().addInsolvencyItem(insolvency);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/insolvency/delta/serialization/ChsDeltaDeserializerTest.java
+++ b/src/test/java/uk/gov/companieshouse/insolvency/delta/serialization/ChsDeltaDeserializerTest.java
@@ -1,0 +1,29 @@
+package uk.gov.companieshouse.insolvency.delta.serialization;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.delta.ChsDelta;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+public class ChsDeltaDeserializerTest {
+
+    private ChsDeltaDeserializer deserializer = new ChsDeltaDeserializer();
+
+    @Test
+    void When_deserialize_Expect_ValidChsDeltaObject() {
+        ChsDelta chsDelta = new ChsDelta("data", 1, "context_id");
+        byte[] data = encodedData(chsDelta);
+
+        ChsDelta deserializedObject = deserializer.deserialize("", data);
+
+        assertThat(deserializedObject).isEqualTo(chsDelta);
+    }
+
+    private byte[] encodedData(ChsDelta chsDelta){
+        ChsDeltaSerializer serializer = new ChsDeltaSerializer();
+        return serializer.serialize("", chsDelta);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/insolvency/delta/transformer/InsolvencyApiTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/insolvency/delta/transformer/InsolvencyApiTransformerTest.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.insolvency.delta.transformer;
 
 import org.junit.Test;
+import uk.gov.companieshouse.api.delta.InsolvencyDelta;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -10,7 +11,7 @@ public class InsolvencyApiTransformerTest {
 
     @Test
     public void transformSuccessfully() {
-        final String input = "test";
+        final InsolvencyDelta input = new InsolvencyDelta();
         assertThat(transformer.transform(input)).isEqualTo(input);
     }
 

--- a/src/test/java/uk/gov/companieshouse/insolvency/delta/transformer/InsolvencyApiTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/insolvency/delta/transformer/InsolvencyApiTransformerTest.java
@@ -1,4 +1,4 @@
-package uk.gov.companieshouse.insolvency.delta.tranformer;
+package uk.gov.companieshouse.insolvency.delta.transformer;
 
 import org.junit.Test;
 

--- a/src/test/resources/insolvency-delta-example.json
+++ b/src/test/resources/insolvency-delta-example.json
@@ -1,0 +1,32 @@
+{
+  "insolvency": [
+    {
+      "company_number": "02588581",
+      "delta_at": "20211008152823383176",
+      "case_numbers": [
+        {
+          "case_number": "1",
+          "case_type_id": "1",
+          "case_type": "Members Voluntary Liquidation",
+          "wind_up_date": "20200506",
+          "sworn_date": "20200429",
+          "appointments": [
+            {
+              "forename": "Bernard",
+              "surname": "Hoffman",
+              "appt_type": "1",
+              "appt_date": "20200506",
+              "practitioner_address": {
+                "address_line_1": "Yerrill Murphy Edelman House",
+                "address_line_2": "1238 High Road",
+                "locality": "Whetstone",
+                "region": "London",
+                "postal_code": "N20 0LH"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Ticket: DSND-417

- Updated private-api-sdk-java dependency to the latest version
- Transformed CHS Delta object into an InsolvencyDelta object using Jackson mapper
- Unit tested the transformation from deserialised CHS Delta into an InsolvencyDelta object (happy path)