### PR TITLE
DSND-710 - Retryable/non-retryable exceptions for delete Insolvency calls

### DIFF
--- a/src/test/java/uk/gov/companieshouse/insolvency/delta/processor/InsolvencyDeltaProcessorTest.java
+++ b/src/test/java/uk/gov/companieshouse/insolvency/delta/processor/InsolvencyDeltaProcessorTest.java
@@ -163,6 +163,7 @@ class InsolvencyDeltaProcessorTest {
     private static Stream<Arguments> provideExceptionParameters() {
         return Stream.of(
                 Arguments.of(HttpStatus.BAD_REQUEST, NonRetryableErrorException.class),
+                Arguments.of(HttpStatus.NOT_FOUND, NonRetryableErrorException.class),
                 Arguments.of(HttpStatus.UNAUTHORIZED, RetryableErrorException.class),
                 Arguments.of(HttpStatus.INTERNAL_SERVER_ERROR, RetryableErrorException.class)
         );


### PR DESCRIPTION
Raise the specified retryable/non-retryable exceptions for insolvency deletes based on the:
- status code of the call to insolvency Data API
- outcome of de-/serialisation of the incoming Kafka message

Resolves:
[DSND-710](https://companieshouse.atlassian.net/browse/DSND-710)