### PR TITLE
Add validation for extra date fields

### DIFF
--- a/src/itest/resources/features/insolvency-delta-error-retry.feature
+++ b/src/itest/resources/features/insolvency-delta-error-retry.feature
@@ -36,3 +36,14 @@ Feature: Process insolvency delta error retry scenarios
     Examples:
       | input         | companyNumber | statusCode | topic                                            |
       | case_type_NPE | 02877511      | 400        | insolvency-delta-insolvency-delta-consumer-error |
+
+  Scenario Outline: Processing insolvency delta information with validation errors
+
+    Given Insolvency delta consumer service is running
+    When a "<message>" with "<companyNumber>" is published to the topic "insolvency-delta" and consumed
+    Then the message should be moved to topic "insolvency-delta-insolvency-delta-consumer-invalid"
+
+    Examples:
+      | message                       | companyNumber |
+      | case_type_1_with_extra_fields | 02877511      |
+      | case_type_3_with_extra_fields | 02877512      |

--- a/src/itest/resources/features/insolvency-delta-error-retry.feature
+++ b/src/itest/resources/features/insolvency-delta-error-retry.feature
@@ -47,3 +47,4 @@ Feature: Process insolvency delta error retry scenarios
       | message                       | companyNumber |
       | case_type_1_with_extra_fields | 02877511      |
       | case_type_3_with_extra_fields | 02877512      |
+      | case_type_7_with_extra_fields | 02877513      |

--- a/src/itest/resources/input/case_type_1_with_extra_fields.json
+++ b/src/itest/resources/input/case_type_1_with_extra_fields.json
@@ -1,0 +1,48 @@
+{
+  "insolvency":[
+    {"delta_at": "20211008152823383176",
+      "company_number":"02877511",
+      "case_numbers":[
+        {
+          "case_number":2,
+          "case_type_id":1,
+          "case_type":"Members Voluntary Liquidation",
+          "mortgage_id":2661659,
+          "wind_up_date":"20200506",
+          "admin_order_date":"20200429",
+          "sworn_date":"20200429",
+          "dissolved_due_date":"20210509",
+          "dissolved_date":"20210506",
+          "appointments":[
+            {
+              "forename":"Happy path 2",
+              "middle_name":"Robert",
+              "surname":"Tucker",
+              "appt_type":1,
+              "practitioner_address":
+              {
+                "address_line_1":"Kpmg",
+                "address_line_2":"8 Salisbury Square",
+                "locality":"London",
+                "region":"",
+                "country":"",
+                "postal_code":"EC4Y 8BB"}},
+            {
+              "forename":"Edward",
+              "middle_name":"George",
+              "surname":"Boyle",
+              "appt_type":1,
+              "practitioner_address":
+              {
+                "address_line_1":"8 Salisbury Square",
+                "address_line_2":"",
+                "locality":"London",
+                "region":"",
+                "country":"",
+                "postal_code":"EC4Y 8BB"}}
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/itest/resources/input/case_type_3_with_extra_fields.json
+++ b/src/itest/resources/input/case_type_3_with_extra_fields.json
@@ -1,0 +1,50 @@
+{
+  "insolvency":[
+    {"delta_at": "20211008152823383176",
+      "company_number":"02877513",
+      "case_numbers":[
+        {
+          "case_number":1,
+          "case_type_id":3,
+          "case_type":"Compulsory Liquidation",
+          "mortgage_id":2661659,
+          "dissolved_due_date":"20200506",
+          "sworn_date":"20200429",
+          "wind_up_conclusion_date":"20210509",
+          "dissolved_date":"20210507",
+          "petition_date":"20210608",
+          "wind_up_date":"20210610",
+          "appointments":[
+            {
+              "forename":"Happy path 6",
+              "middle_name":"Robert",
+              "surname":"Tucker",
+              "appt_type":1,
+              "practitioner_address":
+              {
+                "address_line_1":"Kpmg",
+                "address_line_2":"8 Salisbury Square",
+                "locality":"London",
+                "region":"",
+                "country":"",
+                "postal_code":"EC4Y 8BB"}},
+            {
+              "forename":"Edward",
+              "middle_name":"George",
+              "surname":"Boyle",
+              "appt_type":1,
+              "practitioner_address":
+              {
+                "address_line_1":"8 Salisbury Square",
+                "address_line_2":"",
+                "locality":"London",
+                "region":"",
+                "country":"",
+                "postal_code":"EC4Y 8BB"}}
+          ]
+        }
+      ]
+    }
+  ]
+}
+    

--- a/src/itest/resources/input/case_type_7_with_extra_fields.json
+++ b/src/itest/resources/input/case_type_7_with_extra_fields.json
@@ -1,0 +1,33 @@
+{
+  "insolvency": [
+    {
+      "delta_at": "20211008152823383176",
+      "company_number": "01096138",
+      "case_numbers": [
+        {
+          "case_number": "1",
+          "case_type_id": "7",
+          "case_type": "Administration",
+          "admin_order_date": "20010705",
+          "instrument_date": "20210823",
+          "appointments": [
+            {
+              "forename": "Happy path 9",
+              "middle_name": "",
+              "surname": "Franses",
+              "appt_type": "1",
+              "practitioner_address": {
+                "address_line_1": "Ian Franses Associates",
+                "address_line_2": "24 Conduit Place",
+                "locality": "London",
+                "region": "",
+                "country": "",
+                "postal_code": "W2 1EP"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/java/uk/gov/companieshouse/insolvency/delta/constants/CaseNumberDatesMap.java
+++ b/src/main/java/uk/gov/companieshouse/insolvency/delta/constants/CaseNumberDatesMap.java
@@ -1,0 +1,36 @@
+package uk.gov.companieshouse.insolvency.delta.constants;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class CaseNumberDatesMap {
+    private static final Map<Integer, List<String>> caseDates = new HashMap<>() {
+        {
+            List<String> allDatesList = Arrays.asList("adminEndDate", "adminOrderDate",
+                    "adminStartDate", "appointmentDate", "completionDate",
+                    "dischargeAdminOrderDate", "dissolvedDate", "dissolvedDueDate",
+                    "instrumentDate", "petitionDate", "reportDate", "swornDate",
+                    "windUpConclusionDate", "windUpDate");
+            put(0, allDatesList);
+            put(1, Arrays.asList("dissolvedDueDate","dissolvedDate","swornDate","windUpDate"));
+            put(2, Arrays.asList("dissolvedDueDate","dissolvedDate","windUpDate"));
+            put(3, Arrays.asList("petitionDate","windUpDate","windUpConclusionDate",
+                    "dissolvedDate","dissolvedDueDate"));
+            put(5, Arrays.asList("instrumentDate"));
+            put(6, Arrays.asList("instrumentDate"));
+            put(7, Arrays.asList("adminOrderDate","dischargeAdminOrderDate"));
+            put(8, Arrays.asList("reportDate","completionDate"));
+            put(13, Arrays.asList("adminStartDate","adminEndDate"));
+            //end_date is missing from CaseNumber class, this needs updating
+            put(14, Arrays.asList("appointmentDate","end_date"));
+            //end_date is missing from CaseNumber class, this needs updating
+            put(17, Arrays.asList("appointmentDate","end_date"));
+        }
+    };
+
+    public static Map<Integer, List<String>> getCaseDates() {
+        return caseDates;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/insolvency/delta/validation/InsolvencyDeltaValidator.java
+++ b/src/main/java/uk/gov/companieshouse/insolvency/delta/validation/InsolvencyDeltaValidator.java
@@ -1,0 +1,58 @@
+package uk.gov.companieshouse.insolvency.delta.validation;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.api.delta.CaseNumber;
+import uk.gov.companieshouse.api.delta.Insolvency;
+import uk.gov.companieshouse.insolvency.delta.constants.CaseNumberDatesMap;
+import uk.gov.companieshouse.insolvency.delta.exception.NonRetryableErrorException;
+
+@Component
+public class InsolvencyDeltaValidator {
+
+    /**
+     * Validate case dates for an insolvency.
+     */
+    public void validateCaseDates(Insolvency insolvency) throws Exception {
+
+        List<CaseNumber> caseNumbers = insolvency.getCaseNumbers();
+        Field[] fields = CaseNumber.class.getDeclaredFields();
+        Map<Integer, List<String>> caseDates = CaseNumberDatesMap.getCaseDates();
+
+        for (CaseNumber caseNumber:caseNumbers) {
+            List<String> listOfFieldsToValidate =
+                    buildListOfFieldsToValidateForSchema(caseNumber, caseDates);
+            if (checkFieldAgainstSchema(fields, caseNumber, listOfFieldsToValidate)) {
+                throw new NonRetryableErrorException("Unexpected fields present "
+                        + "for case type Id " + caseNumber.getCaseTypeId());
+            }
+        }
+    }
+
+    private boolean checkFieldAgainstSchema(Field[] fields, CaseNumber caseNumber,
+                                            List<String> listOfFieldsToValidate) throws Exception {
+        for (Field field: fields) {
+            String formattedFieldName = field.getName().substring(0, 1).toUpperCase()
+                    + field.getName().substring(1);
+            Method getter = CaseNumber.class.getMethod("get" + formattedFieldName);
+            if (listOfFieldsToValidate.contains(field.getName())
+                    & getter.invoke(caseNumber) != null) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private List<String> buildListOfFieldsToValidateForSchema(
+            CaseNumber caseNumber, Map<Integer, List<String>> caseDates) {
+        return caseDates.get(0).stream().filter(
+                Predicate.not(caseDates.get(caseNumber.getCaseTypeId().getValue())::contains))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/insolvency/delta/processor/InsolvencyDeltaProcessorTest.java
+++ b/src/test/java/uk/gov/companieshouse/insolvency/delta/processor/InsolvencyDeltaProcessorTest.java
@@ -33,6 +33,7 @@ import uk.gov.companieshouse.insolvency.delta.exception.NonRetryableErrorExcepti
 import uk.gov.companieshouse.insolvency.delta.exception.RetryableErrorException;
 import uk.gov.companieshouse.insolvency.delta.service.api.ApiClientService;
 import uk.gov.companieshouse.insolvency.delta.transformer.InsolvencyApiTransformer;
+import uk.gov.companieshouse.insolvency.delta.validation.InsolvencyDeltaValidator;
 import uk.gov.companieshouse.logging.Logger;
 
 import java.io.IOException;
@@ -45,6 +46,9 @@ class InsolvencyDeltaProcessorTest {
     private InsolvencyDeltaProcessor deltaProcessor;
 
     @Mock
+    InsolvencyDeltaValidator validator;
+
+    @Mock
     private InsolvencyApiTransformer transformer;
 
     @Mock
@@ -55,7 +59,7 @@ class InsolvencyDeltaProcessorTest {
 
     @BeforeEach
     void setUp() {
-        deltaProcessor = new InsolvencyDeltaProcessor(apiClientService, transformer, logger);
+        deltaProcessor = new InsolvencyDeltaProcessor(apiClientService, transformer, logger, validator);
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/insolvency/delta/validation/InsolvencyDeltaValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/insolvency/delta/validation/InsolvencyDeltaValidatorTest.java
@@ -1,0 +1,42 @@
+package uk.gov.companieshouse.insolvency.delta.validation;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.delta.CaseNumber;
+import uk.gov.companieshouse.api.delta.Insolvency;
+import uk.gov.companieshouse.insolvency.delta.exception.NonRetryableErrorException;
+
+import java.io.IOException;
+
+@ExtendWith(MockitoExtension.class)
+public class InsolvencyDeltaValidatorTest {
+
+    InsolvencyDeltaValidator validator;
+
+    @BeforeEach
+    void setUp() {
+        validator = new InsolvencyDeltaValidator();
+    }
+
+    @Test
+    void When_ExtraDateFieldPresent_ForCaseType2_Then_nonRetryableError_isThrown() throws IOException {
+        Insolvency insolvency = new Insolvency();
+        CaseNumber caseNumber = new CaseNumber();
+        caseNumber.setCaseTypeId(CaseNumber.CaseTypeIdEnum.NUMBER_2);
+        caseNumber.setSwornDate("20200429");
+        insolvency.addCaseNumbersItem(caseNumber);
+        Assertions.assertThrows(NonRetryableErrorException.class, () -> validator.validateCaseDates(insolvency));
+    }
+
+    @Test
+    void When_NoExtraDateFieldPresent_ForCaseType2_Then_noError_isThrown() throws IOException {
+        Insolvency insolvency = new Insolvency();
+        CaseNumber caseNumber = new CaseNumber();
+        caseNumber.setCaseTypeId(CaseNumber.CaseTypeIdEnum.NUMBER_2);
+        insolvency.addCaseNumbersItem(caseNumber);
+        Assertions.assertDoesNotThrow(() -> validator.validateCaseDates(insolvency));
+    }
+}


### PR DESCRIPTION
This PR adds a static map with an entry containing all date fields and others containing all present date fields for each case type. This is then used to create a list of fields to validate against in the InsolvencyDeltaValidator. Surplus date fields will throw a NonRetryableError.

**Resolves:**
- DSND-927