### PR TITLE
Add synthetic check

### DIFF
--- a/src/main/java/uk/gov/companieshouse/insolvency/delta/validation/InsolvencyDeltaValidator.java
+++ b/src/main/java/uk/gov/companieshouse/insolvency/delta/validation/InsolvencyDeltaValidator.java
@@ -44,6 +44,9 @@ public class InsolvencyDeltaValidator {
     private boolean checkFieldAgainstSchema(Field[] fields, CaseNumber caseNumber,
                                             List<String> listOfFieldsToValidate) throws Exception {
         for (Field field: fields) {
+            if (field.isSynthetic()) {
+                continue;
+            }
             String formattedFieldName = field.getName().substring(0, 1).toUpperCase()
                     + field.getName().substring(1);
             Method getter = CaseNumber.class.getMethod("get" + formattedFieldName);


### PR DESCRIPTION
This PR adds a synthetic field check to the validator. This is due to make-build compilation adding extra fields to classes such as $jacocoData which aren't added when run in IDEs.
Checkstyle doesn't like this being a one liner -.-