### PR TITLE
Revert "DSND-3109: Update private sdk version"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 		<ch-kafka.version>1.4.2</ch-kafka.version>
 		<structured-logging.version>1.9.37</structured-logging.version>
 		<kafka-models.version>1.0.28</kafka-models.version>
-		<private-api-sdk-java.version>2.0.444</private-api-sdk-java.version>
+		<private-api-sdk-java.version>2.0.443</private-api-sdk-java.version>
 		<api-sdk-manager-java-library.version>1.0.4</api-sdk-manager-java-library.version>
 		<jib-maven-plugin.version>3.1.1</jib-maven-plugin.version>
 		<io-cucumber.version>7.2.3</io-cucumber.version>


### PR DESCRIPTION
Reverts companieshouse/insolvency-delta-consumer#84

We need to test with optional delta_at field on deletes before rolling out required delta_at to avoid issues with a big bang release.